### PR TITLE
Update Provider Versions to latest

### DIFF
--- a/code/infra/terraform.tf
+++ b/code/infra/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azapi = {
       source  = "azure/azapi"
-      version = "1.10.0"
+      version = "1.11.0"
     }
   }
 

--- a/code/infra/terraform.tf
+++ b/code/infra/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.79.0"
+      version = "3.85.0"
     }
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
**Proposed changes**:
- Bump hashicorp/azurerm from 3.79.0 to 3.85.0
- Bump azure/azapi from 1.10.0 to 1.11.0
